### PR TITLE
Fix warning import error.

### DIFF
--- a/sdk/opendp/smartnoise/synthesizers/quail.py
+++ b/sdk/opendp/smartnoise/synthesizers/quail.py
@@ -1,5 +1,5 @@
 import logging
-import warning
+import warnings
 
 from functools import wraps
 
@@ -80,7 +80,7 @@ class QUAILSynthesizer(SDGYMBaseSynthesizer):
         :type data: pd.DataFrame or np.array
         """
         if verbose is not None:
-            warning.warnings("verbose is deprecated. Use logging.setLevel instead")
+            warnings.warn("verbose is deprecated. Use logging.setLevel instead")
 
         from sklearn.model_selection import train_test_split
         from sklearn.metrics import classification_report


### PR DESCRIPTION
I believe the previous `import warning` is an error. It causes `from opendp.smartnoise.synthesizers.quail import QUAILSynthesizer` to fail. 